### PR TITLE
Updated starlight to work with DPMJET 19.3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,7 @@ if(ENABLE_DPMJET)
   #
   # ###
 
+  target_include_directories(${DPMJET_LIB} PRIVATE $ENV{DPMJETDIR}/include/dpmjet)
   set(optionalLibs ${optionalLibs} ${DPMJET_LIB})
   set(optionalLibs ${optionalLibs} "gfortran")
   set(optionalLibs ${optionalLibs} ${DPMJET_EXTERNAL_LIB})

--- a/dpmjet/dpmjetint.f
+++ b/dpmjet/dpmjetint.f
@@ -15,17 +15,15 @@ C      SUBROUTINE CRINT
 * Call the init sub routine in the first event
       DATA INIT /0/
 
-      PARAMETER (NMXHKK=200000)
+      INCLUDE 'inc/dtflka'
 
-      COMMON /DTIONT/ LINP,LOUT,LDAT
-
-      COMMON /DTEVT1/ NHKK,NEVHKK,ISTHKK(NMXHKK),IDHKK(NMXHKK),
-     &                JMOHKK(2,NMXHKK),JDAHKK(2,NMXHKK),
-     &                PHKK(5,NMXHKK),VHKK(4,NMXHKK),WHKK(4,NMXHKK)
+      INCLUDE 'inc/dtevt1'
 
 *     event flag
-      COMMON /DTEVNO/ NEVENT, ICASCA
+      INCLUDE 'inc/dtevno'
 
+      LPRi = 20
+      LOUt = 6
       IF(INIT.EQ.0) THEN
          OPEN (UNIT = 50, file = "my.input")    
 	 LINP = 50
@@ -94,16 +92,10 @@ c     Fill the particle info
 *
 * event history
 
-      PARAMETER (NMXHKK=200000)
-
-      COMMON /DTEVT1/ NHKK,NEVHKK,ISTHKK(NMXHKK),IDHKK(NMXHKK),
-     &                JMOHKK(2,NMXHKK),JDAHKK(2,NMXHKK),
-     &                PHKK(5,NMXHKK),VHKK(4,NMXHKK),WHKK(4,NMXHKK)
+      INCLUDE 'inc/dtevt1'
 
 * extended event history
-      COMMON /DTEVT2/ IDRES(NMXHKK),IDXRES(NMXHKK),NOBAM(NMXHKK),
-     &                IDBAM(NMXHKK),IDCH(NMXHKK),NPOINT(10),
-     &                IHIST(2,NMXHKK)
+      INCLUDE 'inc/dtevt2'
 
       DOUBLE PRECISION SLPX, SLPY, SLPZ, SLE, SLM
       INTEGER SLPID, SLCHARGE

--- a/include/eventchannel.h
+++ b/include/eventchannel.h
@@ -58,7 +58,7 @@ public:
 
 	virtual starlightConstants::event produceEvent(int &ievent) = 0;
 
-	//virtual upcEvent produceEvent(vector3 beta) = 0;
+    virtual upcEvent produceEvent() { return {}; }
 	virtual upcXEvent produceEvent(vector3 beta) = 0;
  
 	static void transform(const double betax,

--- a/include/starlight.h
+++ b/include/starlight.h
@@ -58,7 +58,7 @@ public:
 	bool init();
 
 	vector3 extract_beta(double lorentzGammaBeam1, double lorentzGammaBeam2);
-	//upcEvent produceEvent();
+	upcEvent produceUpcEvent();
 	upcXEvent produceEvent();
       
         std::string   baseFileName  () const { return _baseFileName;		  }

--- a/include/starlightdpmjet.h
+++ b/include/starlightdpmjet.h
@@ -35,6 +35,7 @@ public:
     int init();
     
     virtual upcEvent produceEvent();
+    virtual upcXEvent produceEvent(vector3 /*beta*/) { return {}; }
     
     virtual upcEvent produceSingleEvent(int zdirection, float egamma);
     

--- a/src/starlight.cpp
+++ b/src/starlight.cpp
@@ -227,6 +227,16 @@ starlight::produceEvent()
 	return _eventChannel->produceEvent(beta);
 }
 
+upcEvent
+starlight::produceUpcEvent()
+{
+    if (!_isInitialised) {
+        printErr << "trying to generate event but Starlight is not initialised. aborting." << endl;
+        exit(-1);
+    }
+    return _eventChannel->produceEvent();
+}
+
 /**
  * @brief Determines the boost vector needed to transform from the CM frame to the Lab Frame
  * 

--- a/src/starlightStandalone.cpp
+++ b/src/starlightStandalone.cpp
@@ -137,7 +137,12 @@ starlightStandalone::run()
 		for (unsigned int iEvent = 0; (iEvent < _nmbEventsPerFile) && (nmbEvents < _nmbEventsTot);
 		     ++iEvent, ++nmbEvents) {
 			progressIndicator(iEvent, _nmbEventsTot, true, 4);
-			//upcEvent event = _starlight->produceEvent();
+            if (_inputParameters->interactionType() >= starlightConstants::PHOTONUCLEARSINGLE) {
+              upcEvent event = _starlight->produceUpcEvent();
+              boostEvent(event);
+              fileWriter.writeEvent(event, iEvent);
+              continue;
+            }
 			upcXEvent event = _starlight->produceEvent();
 			// Boost event from CMS system to lab system
 			boostEvent(event);

--- a/src/starlightdpmjet.cpp
+++ b/src/starlightdpmjet.cpp
@@ -27,16 +27,17 @@
 
 extern "C"
 {
+    constexpr size_t nmxhkk = 250000;
     extern struct
         {
 
-            double slpx[200000];
-            double slpy[200000];
-            double slpz[200000];
-            double sle[200000];
-            double slm[200000];
-            int slpid[200000];
-            int slcharge[200000];
+            double slpx[nmxhkk];
+            double slpy[nmxhkk];
+            double slpz[nmxhkk];
+            double sle[nmxhkk];
+            double slm[nmxhkk];
+            int slpid[nmxhkk];
+            int slcharge[nmxhkk];
 
         } dpmjetparticle_;
 


### PR DESCRIPTION
This PR updates the STARlight code to work with the latest version of DPMJET [v19.3.7](https://github.com/DPMJET/DPMJET/releases/tag/v19.3.7) (which implemented recently an update to enable gamma-nucleon and gamma-nucleus collisions in [PR](https://github.com/DPMJET/DPMJET/pull/20)).