### PR TITLE
require C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,11 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   message(STATUS "No build type was specified. Setting build type to 'Release'.")
   set(CMAKE_BUILD_TYPE Release)
 endif()
+
+# Set the C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
 # common compiler flags
 if (CMAKE_COMPILER_IS_GNUCC)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)


### PR DESCRIPTION
c++11 required in CMakeLists.txt to fix
```
 [27%] Building CXX object CMakeFiles/Starlib.dir/src/eventchannel.cpp.o
In file included from /Users/ploskon/devel/STARlight/src/eventchannel.cpp:38:
/Users/ploskon/devel/STARlight/include/eventchannel.h:61:46: error: generalized initializer lists are a C++11 extension [-Werror,-Wc++11-extensions]
virtual upcEvent produceEvent() { return {}; }
^~
/Users/ploskon/devel/STARlight/include/eventchannel.h:61:46: error: non-aggregate type 'upcEvent' cannot be initialized with an initializer list
virtual upcEvent produceEvent() { return {}; }
^~
2 errors generated.
make[2]: *** [CMakeFiles/Starlib.dir/src/eventchannel.cpp.o] Error 1
make[1]: *** [CMakeFiles/Starlib.dir/all] Error 2
make: *** [all] Error 2
```