### PR TITLE
Small changes/fixes needed in ALICE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ message(STATUS "Compiling for system '${CMAKE_SYSTEM_NAME}' version '${CMAKE_SYS
 
 # define build types
 # set a default build type for single-configuration CMake generators, if no build type is set.
-set(CMAKE_BUILD_TYPE Debug)
+
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   message(STATUS "No build type was specified. Setting build type to 'Release'.")
   set(CMAKE_BUILD_TYPE Release)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,9 +301,17 @@ if(ENABLE_DPMJET)
 		)
 endif()
 
+# allow the user to build shared or static via this option
+option(BUILD_SHARED_LIB  "Build shared library instead of static one" OFF)
+if(BUILD_SHARED_LIB)
+    set(LIB_TYPE SHARED)
+else()
+    set(LIB_TYPE STATIC)
+endif()
+
 # add Starlight library to the build system
 set(THIS_LIB "Starlib")
-add_library(${THIS_LIB} STATIC ${SOURCES})
+add_library(${THIS_LIB} ${LIB_TYPE} ${SOURCES})
 #make_shared_library("${THIS_LIB}" "${SOURCES}"
 #	"${PYTHIA8_LIBRARY}"
 #	"${LHAPDF_LIBRARIES}"

--- a/src/photonNucleusCrossSection.cpp
+++ b/src/photonNucleusCrossSection.cpp
@@ -687,7 +687,7 @@ photonNucleusCrossSection::sigma_A(const double sig_N, const int beam)
 	// sig_N,sigma_A in (fm**2) 
 
 	double sum;
-	double b,bmax,Pint,arg,sigma_A_r;
+	double b,bmax,Pint,arg{0},sigma_A_r;
   
 	int NGAUSS;
   


### PR DESCRIPTION
* allow to set the build type from externally (avoid always building in Debug mode)
* allow to build a shared library instead of a static one
* fixing a compiler warning about uninitialized variable (showing up in Release build)