### PR TITLE
Add option to input WoodSaxon parameters

### DIFF
--- a/include/beam.h
+++ b/include/beam.h
@@ -46,6 +46,8 @@ public:
 
 	beam(const int              Z,
 	     const int              A,
+         const double           a,
+         const double           R,
 	     const int		    productionMode,
 	     const double	    beamLorentzGamma);
 	

--- a/include/inputParameters.h
+++ b/include/inputParameters.h
@@ -313,6 +313,11 @@ public:
         double Upsilon3SWidth        () const {return _Upsilon3SWidth        .value();}
         double Upsilon3SBree         () const {return _Upsilon3SBree         .value();}
         double Upsilon3SBrmumu       () const {return _Upsilon3SBrmumu       .value();}
+        double beam1SkinDepth        () const {return _beam1SkinDepth        .value();}
+        double beam2SkinDepth        () const {return _beam2SkinDepth        .value();}
+        double beam1Radius           () const {return _beam1Radius           .value();}
+        double beam2Radius           () const {return _beam2Radius           .value();}
+        double SigmaNNInel           () const {return _SigmaNNInel           .value();}
 	
         void setBaseFileName          (std::string v )  {  _baseFileName = v;     }
     void setHEPMC3_EXTENDED_OUTPUT(bool v)    {_HEPMC3_EXTENDED_OUTPUT = v;}     ///< sets whether slight.out should be extended for more HEPMC3 information or not
@@ -524,6 +529,11 @@ private:
         parameter<double, VALIDITY_CHECK> _Upsilon3SWidth        ;           ///< width of the Upsilon(3S) [GeV/c^2]
         parameter<double, VALIDITY_CHECK> _Upsilon3SBree         ;           ///< branching ratio Upsilon(3S) -> e^+ e^-
         parameter<double, VALIDITY_CHECK> _Upsilon3SBrmumu       ;           ///< branching ratio Upsilon(3S) -> mu^+ mu^-
+        parameter<double, VALIDITY_CHECK> _beam1SkinDepth        ;           ///< Woods-Saxon skin depth of beam particle 1
+        parameter<double, VALIDITY_CHECK> _beam2SkinDepth        ;           ///< Woods-Saxon skin depth of beam particle 2
+        parameter<double, VALIDITY_CHECK> _beam1Radius           ;           ///< Woods-Saxon nuclear radius of beam particle 1
+        parameter<double, VALIDITY_CHECK> _beam2Radius           ;           ///< Woods-Saxon nuclear radius of beam particle 2
+        parameter<double, VALIDITY_CHECK> _SigmaNNInel           ;           ///< inelastic nucleon-nucleon cross section
 	
 	starlightConstants::particleTypeEnum       _particleType;
 	starlightConstants::decayTypeEnum          _decayType;

--- a/include/nucleus.h
+++ b/include/nucleus.h
@@ -46,6 +46,8 @@ public:
 	nucleus();
 	nucleus(const int    Z,
 	        const int    A,
+            const double a,
+            const double R,
 		const int     productionMode);
 	~nucleus();
 	

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -45,10 +45,14 @@ using namespace starlightConstants;
 //______________________________________________________________________________
 beam::beam(const int              Z,
            const int              A,
+           const double           a,
+           const double           R,
 	   const int		  productionMode,
 	   const double		  beamLorentzGamma)
 	: nucleus(Z,
 	          A,
+              a,
+              R,
 		  productionMode)
 	,_beamLorentzGamma(beamLorentzGamma)
 {

--- a/src/beambeamsystem.cpp
+++ b/src/beambeamsystem.cpp
@@ -69,16 +69,21 @@ beamBeamSystem::beamBeamSystem(const inputParameters& inputParametersInstance,
 
 //______________________________________________________________________________
 beamBeamSystem::beamBeamSystem(const inputParameters& inputParametersInstance)
-	: _beamLorentzGamma(inputParametersInstance.beamLorentzGamma()),
+	: _ip(&inputParametersInstance),
+      _beamLorentzGamma(inputParametersInstance.beamLorentzGamma()),
           _beamLorentzGamma1(inputParametersInstance.beam1LorentzGamma()),
           _beamLorentzGamma2(inputParametersInstance.beam2LorentzGamma()),
 	  _beamBreakupMode (inputParametersInstance.beamBreakupMode()),
 	  _beam1           (inputParametersInstance.beam1Z(),
 	                    inputParametersInstance.beam1A(),
+                        inputParametersInstance.beam1SkinDepth(),
+                        inputParametersInstance.beam1Radius(),
 			    inputParametersInstance.productionMode(),
                             inputParametersInstance.beam1LorentzGamma()),
 	  _beam2           (inputParametersInstance.beam2Z(),
 	                    inputParametersInstance.beam2A(),
+                        inputParametersInstance.beam2SkinDepth(),
+                        inputParametersInstance.beam2Radius(),
 			    inputParametersInstance.productionMode(),
                             inputParametersInstance.beam2LorentzGamma()),
 	  _breakupProbabilities(0),
@@ -278,6 +283,7 @@ beamBeamSystem::probabilityOfHadronBreakup(const double impactparameter)
 	mconst=2.076;
 	energyx=energy*energy/pow((2*0.938+mconst),2);
 	  sigmainmb = 0.2838*pow(log(energyx),2)+33.73+13.67*pow(energyx,-0.412)-7.77*pow(energyx,-0.5626);
+      if (_ip->SigmaNNInel() > 0) sigmainmb = _ip->SigmaNNInel();
 	  // end cross-section fix SRK July 2020.  Previously the above equation just used 'energy' from the earlier line
 	  SIGNN=sigmainmb/10.;
 

--- a/src/inputParameters.cpp
+++ b/src/inputParameters.cpp
@@ -175,7 +175,12 @@ inputParameters::inputParameters()
           _Upsilon3SMass         ("Upsilon3SMass"         , 10.3552       , NOT_REQUIRED),
           _Upsilon3SWidth        ("Upsilon3SWidth"        , 0.00002032    , NOT_REQUIRED),
           _Upsilon3SBree         ("Upsilon3SBree"         , 0.0218        , NOT_REQUIRED),
-          _Upsilon3SBrmumu       ("Upsilon3SBrmumu"       , 0.0218        , NOT_REQUIRED)
+          _Upsilon3SBrmumu       ("Upsilon3SBrmumu"       , 0.0218        , NOT_REQUIRED),
+          _beam1SkinDepth        ("BEAM_1_WS_A"           , -1            , NOT_REQUIRED),
+          _beam2SkinDepth        ("BEAM_2_WS_A"           , -1            , NOT_REQUIRED),
+          _beam1Radius           ("BEAM_1_WS_R"           , -1            , NOT_REQUIRED),
+          _beam2Radius           ("BEAM_2_WS_R"           , -1            , NOT_REQUIRED),
+          _SigmaNNInel           ("SigmaNNInel"           , -1            , NOT_REQUIRED)
 {
   // All parameters must be initialised in initialisation list! 
   // If not: error: 'parameter<T, validate>::parameter() [with T = unsigned int, bool validate = true]' is private
@@ -315,6 +320,11 @@ inputParameters::inputParameters()
         _ip.addParameter(_Upsilon3SWidth        );
         _ip.addParameter(_Upsilon3SBree         );
         _ip.addParameter(_Upsilon3SBrmumu       );
+        _ip.addParameter(_beam1SkinDepth        );
+        _ip.addParameter(_beam2SkinDepth        );
+        _ip.addParameter(_beam1Radius           );
+        _ip.addParameter(_beam2Radius           );
+        _ip.addParameter(_SigmaNNInel           );
 }
 
 
@@ -886,6 +896,14 @@ inputParameters::print(ostream& out) const
       out <<"    Minimum impact parameter.................."<<_bmin.value()<<" fm"<<endl;
       out <<"    Maximum impact parameter.................."<<_bmax.value()<<" fm"<<endl;
     }
+    if (_beam1SkinDepth.value()>0 || _beam1Radius.value()>0) {
+      out <<"    beam 1 Woods-Saxon skin depth .......... " << _beam1SkinDepth.value() << " fm" << endl;
+      out <<"    beam 1 Woods-Saxon nuclear radius ...... " << _beam1Radius.value() << " fm" << endl;}
+    if (_beam2SkinDepth.value()>0 || _beam2Radius.value()>0) {
+      out <<"    beam 2 Woods-Saxon skin depth .......... " << _beam2SkinDepth.value() << " fm" << endl;
+      out <<"    beam 2 Woods-Saxon nuclear radius ...... " << _beam2Radius.value() << " fm" << endl;}
+    if (_SigmaNNInel.value()>0)
+      out <<"    inelastic n-n cross section ............ " << _SigmaNNInel.value() << " mb" << endl;
 
     // Add some checks here  SRK September, 2017
     if (_beamBreakupMode.value()==8 && _bmin.value() > _bmax.value()) {

--- a/src/nucleus.cpp
+++ b/src/nucleus.cpp
@@ -46,12 +46,16 @@ using namespace starlightConstants;
 //______________________________________________________________________________
 nucleus::nucleus(const int    Z,
                  const int    A,
+                 const double a,
+                 const double R,
 		 const int    productionMode)
 	: _Z(Z),
 	  _A(A),
 	  _productionMode(productionMode)
 {
   init();	
+  if (a > 0) _woodSaxonSkinDepth = a;
+  if (R > 0) _Radius = R;
 }
 
 void nucleus::init()


### PR DESCRIPTION
This PR addresses https://github.com/STARlightsim/STARlight/issues/8

It adds the option to input the WoodSaxon (skin depth and radius) and inelastic cross section in the input card settings.

@SpencerKlein 