### PR TITLE
Build option for dpmjet library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,7 @@ if(ENABLE_DPMJET)
   # new (Luan Arbeletche):
   #
   message(STATUS "DPMJet external library: ${DPMJET_EXTERNAL_LIB}")
-  add_library(${DPMJET_LIB} STATIC dpmjet/dpmjetint.f)
+  add_library(${DPMJET_LIB} ${LIB_TYPE} dpmjet/dpmjetint.f)
   #
   # ###
 


### PR DESCRIPTION
In order to build STARlight agains DPMJET in ALICE O2 we need a possibility to build corresponding library as SHARED.  

@SpencerKlein   