### PR TITLE
Fix HepMC3 Vertex issue + Handle correctly file closure

### DIFF
--- a/include/eventfilewriter.h
+++ b/include/eventfilewriter.h
@@ -54,8 +54,14 @@ class eventFileWriter : public fileWriter
       /** Constructor with name */
       eventFileWriter(std::string filename);
 
+      /** Destructor */
+      ~eventFileWriter();
+
       /** Write out simulation set up */
       int writeInit(inputParameters &param );
+
+      /** Close output files */
+      int close();
 
       /** Write an UPC event to file */
       int writeEvent(upcEvent &event, int eventnumber);

--- a/src/eventfilewriter.cpp
+++ b/src/eventfilewriter.cpp
@@ -39,6 +39,9 @@
 eventFileWriter::eventFileWriter()
 : fileWriter()
 ,_writeFullPythia(false)
+#ifdef HEPMC3_ON
+,_hepmc3writer(nullptr)
+#endif
 { }
 
 
@@ -46,6 +49,17 @@ eventFileWriter::eventFileWriter()
 eventFileWriter::eventFileWriter(std::string filename)
 : fileWriter(filename)
 { }
+
+//______________________________________________________________________________
+eventFileWriter::~eventFileWriter()
+{
+#ifdef HEPMC3_ON
+    if (_hepmc3writer) {
+        delete _hepmc3writer;
+        _hepmc3writer = nullptr;
+    }
+#endif
+}
 
 //______________________________________________________________________________
 int eventFileWriter::writeInit(inputParameters &_p)
@@ -69,6 +83,17 @@ int eventFileWriter::writeInit(inputParameters &_p)
   _ip = _p;
   
   return 0;
+}
+
+//______________________________________________________________________________
+int eventFileWriter::close()
+{
+#ifdef HEPMC3_ON
+    if (_hepmc3writer) {
+        _hepmc3writer->close();
+    }
+#endif
+    return fileWriter::close();
 }
 
 //______________________________________________________________________________

--- a/src/hepmc3writer.cpp
+++ b/src/hepmc3writer.cpp
@@ -17,6 +17,16 @@ using namespace std;
 
 hepMC3Writer::hepMC3Writer()
 {}
+
+hepMC3Writer::~hepMC3Writer()
+{
+    if (_hepmc3_output) {
+        _hepmc3_output->close();
+        delete _hepmc3_output;
+        _hepmc3_output = nullptr;
+    }
+}
+
 int hepMC3Writer::initWriter(const inputParameters &param)
 {
     std::string hepmc3_filename = param.baseFileName() + ".hepmc";
@@ -147,11 +157,11 @@ int hepMC3Writer::writeEvent(const upcXEvent &event, int eventnumber){
         HepMC3::GenParticlePtr hepmc3_beam1_out = std::make_shared<HepMC3::GenParticle>(FourVector(beam_1.GetPx(),
                                                                                                     beam_1.GetPy(),
                                                                                                     beam_1.GetPz(),
-                                                                                                    beam_1.GetE()),beam1_pdg_id,1);
+                                                                                                    beam_1.GetE()),beam1_pdg_id,4);
         HepMC3::GenParticlePtr hepmc3_beam2_out = std::make_shared<HepMC3::GenParticle>(FourVector(beam_2.GetPx(),
                                                                                                     beam_2.GetPy(),
                                                                                                     beam_2.GetPz(),
-                                                                                                    beam_2.GetE()),beam2_pdg_id,1);
+                                                                                                    beam_2.GetE()),beam2_pdg_id,4);
 
 
         lorentzVector vmeson = event.getVectorMeson();
@@ -159,25 +169,21 @@ int hepMC3Writer::writeEvent(const upcXEvent &event, int eventnumber){
 
         const std::vector<starlightParticle> * particle_vector = event.getParticles();
 
-        HepMC3::GenVertexPtr hepmc3_root_vertex = std::make_shared<HepMC3::GenVertex>(FourVector(0,0,0,0));
         HepMC3::GenVertexPtr hepmc3_gamEmit_vertex = std::make_shared<HepMC3::GenVertex>(FourVector(0,0,0,0));
         HepMC3::GenVertexPtr hepmc3_VMProd_vertex = std::make_shared<HepMC3::GenVertex>(FourVector(0,0,0,0));
         HepMC3::GenVertexPtr hepmc3_PartProd_vertex = std::make_shared<HepMC3::GenVertex>(FourVector(0,0,0,0));
 
         hepmc3_evt.add_particle(hepmc3_beam1_in);
         hepmc3_evt.add_particle(hepmc3_beam2_in);
+        hepmc3_evt.set_beam_particles(hepmc3_beam1_in, hepmc3_beam2_in);
         if(event.targetBeamNo() == 1){
             hepmc3_evt.add_particle(gamma_particle);
             hepmc3_evt.add_particle(hepmc3_beam2_out);
             hepmc3_evt.add_particle(hepmc3_beam1_out);
             hepmc3_evt.add_particle(hepmc3_vector_meson);
-            hepmc3_evt.add_vertex(hepmc3_root_vertex);
             hepmc3_evt.add_vertex(hepmc3_gamEmit_vertex);
             hepmc3_evt.add_vertex(hepmc3_VMProd_vertex);
             hepmc3_evt.add_vertex(hepmc3_PartProd_vertex);
-            
-            hepmc3_root_vertex->add_particle_out(hepmc3_beam1_in);
-            hepmc3_root_vertex->add_particle_out(hepmc3_beam2_in);
 
             hepmc3_gamEmit_vertex->add_particle_in(hepmc3_beam2_in);
             hepmc3_gamEmit_vertex->add_particle_out(gamma_particle);
@@ -196,13 +202,9 @@ int hepMC3Writer::writeEvent(const upcXEvent &event, int eventnumber){
             hepmc3_evt.add_particle(gamma_particle);
             hepmc3_evt.add_particle(hepmc3_vector_meson);
             hepmc3_evt.add_particle(hepmc3_beam2_out);
-            hepmc3_evt.add_vertex(hepmc3_root_vertex);
             hepmc3_evt.add_vertex(hepmc3_gamEmit_vertex);
             hepmc3_evt.add_vertex(hepmc3_VMProd_vertex);
             hepmc3_evt.add_vertex(hepmc3_PartProd_vertex);
-
-            hepmc3_root_vertex->add_particle_out(hepmc3_beam1_in);
-            hepmc3_root_vertex->add_particle_out(hepmc3_beam2_in);
 
             hepmc3_gamEmit_vertex->add_particle_in(hepmc3_beam1_in);
             hepmc3_gamEmit_vertex->add_particle_out(hepmc3_beam1_out);
@@ -243,7 +245,7 @@ int hepMC3Writer::writeEvent(const upcXEvent &event, int eventnumber){
         HepMC3::GenParticlePtr hepmc3_beam1_out = std::make_shared<HepMC3::GenParticle>(FourVector(beam_1.GetPx(),
                                                                                                     beam_1.GetPy(),
                                                                                                     beam_1.GetPz(),
-                                                                                                    beam_1.GetE()),beam1_pdg_id,1);
+                                                                                                    beam_1.GetE()),beam1_pdg_id,4);
         
 
         lorentzVector gamma1 = event.getGammaFromBeam1().gamma;
@@ -261,7 +263,7 @@ int hepMC3Writer::writeEvent(const upcXEvent &event, int eventnumber){
         HepMC3::GenParticlePtr hepmc3_beam2_out = std::make_shared<HepMC3::GenParticle>(FourVector(beam_2.GetPx(),
                                                                                                     beam_2.GetPy(),
                                                                                                     beam_2.GetPz(),
-                                                                                                    beam_2.GetE()),beam2_pdg_id,1);
+                                                                                                    beam_2.GetE()),beam2_pdg_id,4);
         
         HepMC3::GenParticlePtr hepmc3_meson, hepmc3_meson2;
         if(!leptonpair){
@@ -277,7 +279,6 @@ int hepMC3Writer::writeEvent(const upcXEvent &event, int eventnumber){
         //decay product particles created later
 
         //2. create vertex
-        HepMC3::GenVertexPtr hepmc3_root_vertex = std::make_shared<HepMC3::GenVertex>(FourVector(0,0,0,0));
         HepMC3::GenVertexPtr hepmc3_beam1gamEmit_vertex = std::make_shared<HepMC3::GenVertex>(FourVector(0,0,0,0));
         HepMC3::GenVertexPtr hepmc3_beam2gamEmit_vertex = std::make_shared<HepMC3::GenVertex>(FourVector(0,0,0,0));
 
@@ -291,6 +292,7 @@ int hepMC3Writer::writeEvent(const upcXEvent &event, int eventnumber){
 
         hepmc3_evt.add_particle(hepmc3_beam1_in);
         hepmc3_evt.add_particle(hepmc3_beam2_in);
+        hepmc3_evt.set_beam_particles(hepmc3_beam1_in, hepmc3_beam2_in);
         hepmc3_evt.add_particle(hepmc3_beam1_out);
         hepmc3_evt.add_particle(gamma_particle1);
         hepmc3_evt.add_particle(gamma_particle2);
@@ -300,7 +302,6 @@ int hepMC3Writer::writeEvent(const upcXEvent &event, int eventnumber){
         //decay product particles added later
 
         //4. add vertex to event
-        hepmc3_evt.add_vertex(hepmc3_root_vertex);
         hepmc3_evt.add_vertex(hepmc3_beam1gamEmit_vertex);
         hepmc3_evt.add_vertex(hepmc3_beam2gamEmit_vertex);
         if(!leptonpair) hepmc3_evt.add_vertex(hepmc3_VMProd_vertex);
@@ -309,9 +310,6 @@ int hepMC3Writer::writeEvent(const upcXEvent &event, int eventnumber){
 
 
         //5. add particles to vertex
-        hepmc3_root_vertex->add_particle_out(hepmc3_beam1_in);
-        hepmc3_root_vertex->add_particle_out(hepmc3_beam2_in);
-
         hepmc3_beam1gamEmit_vertex->add_particle_in(hepmc3_beam1_in);
         hepmc3_beam1gamEmit_vertex->add_particle_out(hepmc3_beam1_out);
         hepmc3_beam1gamEmit_vertex->add_particle_out(gamma_particle1);


### PR DESCRIPTION
Three issues were present while creating HepMC3 files:
- The Beams need to have status 4 ==> this was causing the ALICE issues in primary particles in the O2 framework
- An explicit vertex should not be present for the beams ==> this was causing the `ERROR::ReaderAscii: not enough implicit vertices`, now fixed
- The Writer was not closed and destroyed properly ==> the HepMC output was always lacking the last event. I noticed this behaviour while testing the system to fix the other two issues. The correct number of events and HepMC footer are now set in the HepMC output.

**IMPORTANT** = I touched only the HepMC output, so that it works as expected, I didn't touch at all the physics behind it and tried to keep my modifications to a minimum. 